### PR TITLE
Hook search up to results

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2452,6 +2452,22 @@
         "randombytes": "2.0.5"
       }
     },
+    "disposables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.1.tgz",
+      "integrity": "sha1-BkcnoltU9QK9griaot+4358bOeM="
+    },
+    "dnd-core": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.4.tgz",
+      "integrity": "sha512-BcI782MfTm3wCxeIS5c7tAutyTwEIANtuu3W6/xkoJRwiqhRXKX3BbGlycUxxyzMsKdvvoavxgrC3EMPFNYL9A==",
+      "requires": {
+        "asap": "2.0.6",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "redux": "3.7.2"
+      }
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -5050,6 +5066,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -7435,6 +7456,27 @@
         }
       }
     },
+    "react-dnd": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.5.4.tgz",
+      "integrity": "sha512-y9YmnusURc+3KPgvhYKvZ9oCucj51MSZWODyaeV0KFU0cquzA7dCD1g/OIYUKtNoZ+MXtacDngkdud2TklMSjw==",
+      "requires": {
+        "disposables": "1.0.1",
+        "dnd-core": "2.5.4",
+        "hoist-non-react-statics": "2.3.1",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-dnd-html5-backend": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.5.4.tgz",
+      "integrity": "sha512-jDqAkm/hI8Tl4HcsbhkBgB6HgpJR1e+ML1SbfxaegXYiuMxEVQm0FOwEH5WxUoo6fmIG4N+H0rSm59POuZOCaA==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "react-dom": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
@@ -7713,6 +7755,17 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         }
+      }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
       }
     },
     "regenerate": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import Search from "./Search";
 import Calendar from "./Calendar";
 import Results from "./Results";
+import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 
 class App extends Component {
   constructor(props) {
@@ -10,11 +11,13 @@ class App extends Component {
 
   render() {
     return (
-      <div>
-        <Calendar />
-        <Search />
-        <Results />
-      </div>
+      <MuiThemeProvider>
+        <div>
+          <Calendar />
+          <Search />
+          <Results results={results} />
+        </div>
+      </MuiThemeProvider>
     );
   }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,11 +11,9 @@ class App extends Component {
     this.state = {
       term: ""
     };
-
-    this.onSearchSubmit = this.onSearchSubmit.bind(this);
   }
 
-  onSearchSubmit(term) {
+  onSearchSubmit = (term) => {
     this.setState({ term });
   }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,20 +7,33 @@ import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 class App extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      term: ""
+    };
+
+    this.onSearchSubmit = this.onSearchSubmit.bind(this);
+  }
+
+  onSearchSubmit(term) {
+    this.setState({ term });
   }
 
   render() {
+    const { term } = this.state;
+
     let results = [
       { name: "CMPSC 40", times: "M W 2:00 p.m - 3:15 p.m" },
       { name: "CMPSC 56", times: "T R 9:30 a.m - 10:45 a.m" },
       { name: "CMPSC 130A", times: "M W 9:30 a.m - 10:45 a.m" }
     ];
+
     return (
       <MuiThemeProvider>
         <div>
           <Calendar />
-          <Search />
-          <Results results={results} />
+          <Search onSubmit={this.onSearchSubmit} />
+          <Results filterTerm={term} results={results} />
         </div>
       </MuiThemeProvider>
     );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,11 @@ class App extends Component {
   }
 
   render() {
+    let results = [
+      { name: "CMPSC 40", times: "M W 2:00 p.m - 3:15 p.m" },
+      { name: "CMPSC 56", times: "T R 9:30 a.m - 10:45 a.m" },
+      { name: "CMPSC 130A", times: "M W 9:30 a.m - 10:45 a.m" }
+    ];
     return (
       <MuiThemeProvider>
         <div>

--- a/client/src/Results/Result.js
+++ b/client/src/Results/Result.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { TableRow, TableRowColumn } from 'material-ui/Table';
+import RaisedButton from 'material-ui/RaisedButton';
+
+const Result = ({ name, times}) => (
+	<TableRow>
+		<TableRowColumn>{name}</TableRowColumn>
+		<TableRowColumn>{times}</TableRowColumn>
+		<TableRowColumn>
+			<RaisedButton label="Add" primary />
+		</TableRowColumn>
+	</TableRow>
+);
+
+export default Result;

--- a/client/src/Results/index.js
+++ b/client/src/Results/index.js
@@ -29,7 +29,7 @@ class Results extends Component {
               <TableRowColumn>{result.name}</TableRowColumn>
               <TableRowColumn>{result.times}</TableRowColumn>
               <TableRowColumn>
-                <RaisedButton raised color="accent">Add</RaisedButton>
+                <RaisedButton label="Add" primary />
               </TableRowColumn>
             </TableRow>
           ))}

--- a/client/src/Results/index.js
+++ b/client/src/Results/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
-import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
-import RaisedButton from 'material-ui/RaisedButton';
+import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table';
+import Result from "./Result";
 
 class Results extends Component {
   constructor(props) {
@@ -24,15 +24,7 @@ class Results extends Component {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {results.map((result) => (
-            <TableRow>
-              <TableRowColumn>{result.name}</TableRowColumn>
-              <TableRowColumn>{result.times}</TableRowColumn>
-              <TableRowColumn>
-                <RaisedButton label="Add" primary />
-              </TableRowColumn>
-            </TableRow>
-          ))}
+          {results.map((result) => ( <Result {...result} key={result.name}/> ))}
         </TableBody>
       </Table>
     );

--- a/client/src/Search/index.js
+++ b/client/src/Search/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import SearchBar from "material-ui-search-bar";
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 
 class Search extends Component {
   constructor(props) {
@@ -9,16 +8,16 @@ class Search extends Component {
 
   render() {
     return (
-      <MuiThemeProvider>
-        <SearchBar
-          onChange={() => console.log('onChange')}
-          onRequestSearch={() => console.log('onRequestSearch')}
-          style={{
-            margin: '0 auto',
-            maxWidth: 800
-          }}
-        />
-      </MuiThemeProvider>
+      <SearchBar
+        onChange={() => console.log("onChange")}
+        onRequestSearch={() => console.log("onRequestSearch")}
+        style={{
+          margin: "0 auto",
+          marginBottom: "10px",
+          marginTop: "15px",
+          maxWidth: 800
+        }}
+      />
     );
   }
 }

--- a/client/src/Search/index.js
+++ b/client/src/Search/index.js
@@ -4,19 +4,37 @@ import SearchBar from "material-ui-search-bar";
 class Search extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      term: ""
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.onRequestSearch = this.onRequestSearch.bind(this);
+  }
+
+  onChange(term) {
+    this.setState({ term });
+  }
+
+  onRequestSearch() {
+    this.props.onSubmit(this.state.term);
   }
 
   render() {
+    const { term } = this.state;
+
     return (
       <SearchBar
-        onChange={() => console.log("onChange")}
-        onRequestSearch={() => console.log("onRequestSearch")}
+        onChange={this.onChange}
+        onRequestSearch={this.onRequestSearch}
         style={{
           margin: "0 auto",
           marginBottom: "10px",
           marginTop: "15px",
           maxWidth: 800
         }}
+        value={term}
       />
     );
   }

--- a/client/src/Search/index.js
+++ b/client/src/Search/index.js
@@ -8,16 +8,13 @@ class Search extends Component {
     this.state = {
       term: ""
     };
-
-    this.onChange = this.onChange.bind(this);
-    this.onRequestSearch = this.onRequestSearch.bind(this);
   }
 
-  onChange(term) {
+  onChange = (term) => {
     this.setState({ term });
   }
 
-  onRequestSearch() {
+  onRequestSearch = () => {
     this.props.onSubmit(this.state.term);
   }
 


### PR DESCRIPTION
This PR introduces infrastructure changes to the HOC, Search, and Results component to allow the search component to add filters to the Results table.

What it looks like generally:
![image](https://user-images.githubusercontent.com/15878248/31962465-7bdf6842-b8b2-11e7-890a-6e1970f62ea9.png)

Results Component receiving the filter term:
![image](https://user-images.githubusercontent.com/15878248/31962490-8f633376-b8b2-11e7-8cea-9fd37f1e318f.png)
