### PR TITLE
Create likes and users table

### DIFF
--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -3,4 +3,11 @@ class CourseController < ApplicationController
 		@courses = Course.all
 		render json: @courses
 	end
+
+	def like
+		@like = Like.find_or_create_by(user: User.first, course_id: params[:id])
+		@like.amount += 1
+		@like.save!
+		render json: @like
+	end
 end

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -7,7 +7,6 @@ class CourseController < ApplicationController
 		SQL
 
 		@courses = ActiveRecord::Base.connection.execute(find_courses_sql)
-		
 		render json: @courses
 	end
 

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -1,6 +1,13 @@
 class CourseController < ApplicationController
 	def all
-		@courses = Course.all
+		find_courses_sql = <<-SQL
+			SELECT courses.*, COALESCE(SUM(likes.amount), 0) as likes
+			FROM courses LEFT JOIN likes ON likes.course_id = courses.id
+			GROUP BY courses.id;
+		SQL
+
+		@courses = ActiveRecord::Base.connection.execute(find_courses_sql)
+		
 		render json: @courses
 	end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,4 @@
 class Course < ApplicationRecord
 	belongs_to :instructor
-	has_many :likes
+	has_many :likes, dependent: :delete_all
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,3 +1,4 @@
 class Course < ApplicationRecord
 	belongs_to :instructor
+	has_many :likes
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,7 @@
 class Like < ApplicationRecord
 	belongs_to :course
 	belongs_to :user
+
+	validates_inclusion_of :amount, in: (0..10).to_a,
+		message: 'You cannot like a course more than 10 times'
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+	belongs_to :course
+	belongs_to :user
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -2,6 +2,8 @@ class Like < ApplicationRecord
 	belongs_to :course
 	belongs_to :user
 
-	validates_inclusion_of :amount, in: (0..10).to_a,
-		message: 'You cannot like a course more than 10 times'
+	validates :amount, inclusion: {
+			in: (0..10).to_a,
+			message: 'You cannot like a course more than 10 times'
+	}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	get 'course/all', to: 'course#all'
-	get 'course/:id/like', to: 'course#like' 
+	get 'course/:id/like', to: 'course#like'
 
 	get '*path', to: 'application#fallback_index_html', constraints: lambda { |request|
 		!request.xhr? && request.format.html?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	get 'course/all', to: 'course#all'
+	get 'course/:id/like', to: 'course#like' 
 
 	get '*path', to: 'application#fallback_index_html', constraints: lambda { |request|
 		!request.xhr? && request.format.html?

--- a/db/migrate/20171109194411_create_users.rb
+++ b/db/migrate/20171109194411_create_users.rb
@@ -1,0 +1,7 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171109194857_create_likes.rb
+++ b/db/migrate/20171109194857_create_likes.rb
@@ -1,0 +1,13 @@
+class CreateLikes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :likes do |t|
+      t.integer :amount, default: 0, null: false
+
+      t.references 'course', foreign_key: true
+      t.references 'user', foreign_key: true
+
+      t.index [:course_id, :user_id], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101024810) do
+ActiveRecord::Schema.define(version: 20171109194411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,11 @@ ActiveRecord::Schema.define(version: 20171101024810) do
     t.string "location"
     t.bigint "course_id"
     t.index ["course_id"], name: "index_periods_on_course_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "courses", "instructors"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109194411) do
+ActiveRecord::Schema.define(version: 20171109194857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,17 @@ ActiveRecord::Schema.define(version: 20171109194411) do
     t.string "rmp_url"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.integer "amount", default: 0, null: false
+    t.bigint "course_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id", "user_id"], name: "index_likes_on_course_id_and_user_id", unique: true
+    t.index ["course_id"], name: "index_likes_on_course_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "periods", id: false, force: :cascade do |t|
     t.time "start_time"
     t.time "end_time"
@@ -47,4 +58,6 @@ ActiveRecord::Schema.define(version: 20171109194411) do
   end
 
   add_foreign_key "courses", "instructors"
+  add_foreign_key "likes", "courses"
+  add_foreign_key "likes", "users"
 end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  amount: 1
+
+two:
+  amount: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
We are allowing users to like courses. A limit of up to 10 likes is imposed on a per user / course basis.

Caveat: We have not implemented User accounts yet, so the like user is defaulted to the first user in the database

This pull request introduces two new tables:
- Likes
- Users

![image](https://user-images.githubusercontent.com/15878248/32629663-d11857ee-c54e-11e7-9931-99da177e84cf.png)
