### PR TITLE
Add course comments

### DIFF
--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -23,8 +23,14 @@ class CourseController < ApplicationController
 		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content])
 
 		render json: @comment
-
 	rescue ActiveRecord::RecordNotFound
-		render json: { status: "failed" }
+		render json: { status: 'failed' }, status: 500
+	end
+
+	def show
+		course = Course.find(params[:id])
+		render json: course.to_json(include: :comments)
+	rescue ActiveRecord::RecordNotFound
+		render json: { status: 'failed' }, status: 500
 	end
 end

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -16,4 +16,15 @@ class CourseController < ApplicationController
 		@like.save!
 		render json: @like
 	end
+
+	def comment
+		course = Course.find(params[:id])
+		user = User.first # hardcode user for now
+		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content])
+
+		render json: @comment
+
+	rescue ActiveRecord::RecordNotFound
+		render json: { status: "failed" }
+	end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,4 +2,5 @@ class Course < ApplicationRecord
 	belongs_to :instructor
 	has_many :likes, dependent: :delete_all
 	has_many :periods, dependent: :destroy
+	has_many :comments, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	get 'course/all', to: 'course#all'
 	get 'course/:id/like', to: 'course#like'
+	post 'course/:id/comment', to: 'course#comment'
 
 	get '*path', to: 'application#fallback_index_html', constraints: lambda { |request|
 		!request.xhr? && request.format.html?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	get 'course/all', to: 'course#all'
 	get 'course/:id/like', to: 'course#like'
+	get 'course/:id', to: 'course#show'
 	post 'course/:id/comment', to: 'course#comment'
 
 	get '*path', to: 'application#fallback_index_html', constraints: lambda { |request|

--- a/db/migrate/20171116014733_create_comments.rb
+++ b/db/migrate/20171116014733_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :comments do |t|
+		t.text :content, null: false, default: ""
+		t.references 'user', foreign_key: true, null: false
+		t.references 'course', foreign_key: true, null: false
+
+		t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171114041958) do
+ActiveRecord::Schema.define(version: 20171116014733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "content", default: "", null: false
+    t.bigint "user_id", null: false
+    t.bigint "course_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_comments_on_course_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "courses", force: :cascade do |t|
     t.string "dept"
@@ -59,6 +69,8 @@ ActiveRecord::Schema.define(version: 20171114041958) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "comments", "courses"
+  add_foreign_key "comments", "users"
   add_foreign_key "courses", "instructors"
   add_foreign_key "likes", "courses"
   add_foreign_key "likes", "users"

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR introduces the comments model and integration.

You can comment on a post by accessing the "/course/:(course)id/comment"
You can access the course and its corresponding comments by accessing the route "/course/:(course)id"