### PR TITLE
Add filter course support

### DIFF
--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -3,13 +3,23 @@ class CourseController < ApplicationController
 
 	def preview
 		find_courses_sql = <<-SQL
-			SELECT courses.*, COALESCE(SUM(likes.amount), 0) as likes
-			FROM courses LEFT JOIN likes ON likes.course_id = courses.id
+			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
+			FROM courses LEFT JOIN course_likes ON course_likes.course_id = courses.id
 			GROUP BY courses.id
 			LIMIT 100;
 		SQL
 
 		@courses = ActiveRecord::Base.connection.execute(find_courses_sql)
+		render json: @courses
+	end
+
+	def filter
+		filter_conditions = []
+		filter_conditions.push("courses.dept='#{params[:dept]}'") unless params[:dept].nil?
+
+		filter_courses_sql = generate_filter_courses_sql(filter_conditions)
+
+		@courses = ActiveRecord::Base.connection.execute(filter_courses_sql)
 		render json: @courses
 	end
 
@@ -37,5 +47,17 @@ class CourseController < ApplicationController
 		render json: course.to_json(include: :comments)
 	rescue ActiveRecord::RecordNotFound
 		render json: { status: 'failed' }, status: 500
+	end
+
+		private
+
+	def generate_filter_courses_sql(filter_conditions)
+		<<-SQL
+			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
+			FROM courses LEFT JOIN course_likes ON course_likes.course_id = courses.id
+			#{'WHERE ' + filter_conditions.join(' AND ') if filter_conditions.present?}
+			GROUP BY courses.id
+			LIMIT 100;
+		SQL
 	end
 end

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -1,11 +1,12 @@
 class CourseController < ApplicationController
 	before_action :authenticate_user, only: [:like, :comment]
 
-	def all
+	def preview
 		find_courses_sql = <<-SQL
-			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
-			FROM courses LEFT JOIN course_likes ON course_likes.course_id = courses.id
-			GROUP BY courses.id;
+			SELECT courses.*, COALESCE(SUM(likes.amount), 0) as likes
+			FROM courses LEFT JOIN likes ON likes.course_id = courses.id
+			GROUP BY courses.id
+			LIMIT 100;
 		SQL
 
 		@courses = ActiveRecord::Base.connection.execute(find_courses_sql)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 	post 'comment/:id/reply', to: 'comment#reply'
 
 	get 'course/all', to: 'course#all'
+	get 'course/preview', to: 'course#preview'
 	get 'course/:id', to: 'course#show'
 	post 'course/:id/like', to: 'course#like'
 	post 'course/:id/comment', to: 'course#comment'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
 	get 'course/all', to: 'course#all'
 	get 'course/preview', to: 'course#preview'
+	get 'course/filter', to: 'course#filter'
 	get 'course/:id', to: 'course#show'
 	post 'course/:id/like', to: 'course#like'
 	post 'course/:id/comment', to: 'course#comment'


### PR DESCRIPTION
Since we're dealing with large amounts of data, it isn't a good idea to load all of the data through an endpoint. (81 million courses...)

Preview:
The route /course/preview will load up to a fixed amount of 100 courses.

Filter:
You can now filter for courses by accessing /course/filter with query params to specify the filters.
The only supported filter is department. 
Sample: /course/filter?dept=Computer+Science