### PR TITLE
Add liking and replying actions to comments

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -4,10 +4,19 @@ class CommentController < ApplicationController
 		@like.amount += 1
 		@like.save!
 		render json: @like
+	rescue ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordInvalid
+		render json: { status: 'failed' }, status: 500
+	end
 
-	rescue ActiveRecord::RecordNotFound
-	rescue ActiveRecord::InvalidForeignKey
-	rescue ActiveRecord::RecordInvalid
+	def reply
+		comment = Comment.find(params[:id])
+		parent_id = params[:id]
+
+		user = current_user
+		@comment = Comment.create!(course_id: comment.course_id, user_id: user.id, content: params[:content], parent_id: parent_id)
+
+		render json: @comment
+	rescue ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordInvalid
 		render json: { status: 'failed' }, status: 500
 	end
 end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -1,0 +1,13 @@
+class CommentController < ApplicationController
+	def like
+		@like = CommentLike.find_or_create_by(user: current_user, comment_id: params[:id])
+		@like.amount += 1
+		@like.save!
+		render json: @like
+
+	rescue ActiveRecord::RecordNotFound
+	rescue ActiveRecord::InvalidForeignKey
+	rescue ActiveRecord::RecordInvalid
+		render json: { status: 'failed' }, status: 500
+	end
+end

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -21,11 +21,13 @@ class CourseController < ApplicationController
 
 	def comment
 		course = Course.find(params[:id])
+		parent_id = params[:parent_id]
 		user = current_user
-		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content])
+		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content], parent_id: parent_id)
 
 		render json: @comment
 	rescue ActiveRecord::RecordNotFound
+	rescue ActiveRecord::InvalidForeignKey
 		render json: { status: 'failed' }, status: 500
 	end
 

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -17,6 +17,10 @@ class CourseController < ApplicationController
 		@like.amount += 1
 		@like.save!
 		render json: @like
+	rescue ActiveRecord::RecordNotFound
+	rescue ActiveRecord::InvalidForeignKey
+	rescue ActiveRecord::RecordInvalid
+		render json: { status: 'failed' }, status: 500
 	end
 
 	def comment

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -17,21 +17,17 @@ class CourseController < ApplicationController
 		@like.amount += 1
 		@like.save!
 		render json: @like
-	rescue ActiveRecord::RecordNotFound
-	rescue ActiveRecord::InvalidForeignKey
-	rescue ActiveRecord::RecordInvalid
+	rescue ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordInvalid
 		render json: { status: 'failed' }, status: 500
 	end
 
 	def comment
 		course = Course.find(params[:id])
-		parent_id = params[:parent_id]
 		user = current_user
-		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content], parent_id: parent_id)
+		@comment = Comment.create!(course_id: course.id, user_id: user.id, content: params[:content])
 
 		render json: @comment
-	rescue ActiveRecord::RecordNotFound
-	rescue ActiveRecord::InvalidForeignKey
+	rescue ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordInvalid
 		render json: { status: 'failed' }, status: 500
 	end
 

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -3,8 +3,8 @@ class CourseController < ApplicationController
 
 	def all
 		find_courses_sql = <<-SQL
-			SELECT courses.*, COALESCE(SUM(likes.amount), 0) as likes
-			FROM courses LEFT JOIN likes ON likes.course_id = courses.id
+			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
+			FROM courses LEFT JOIN course_likes ON course_likes.course_id = courses.id
 			GROUP BY courses.id;
 		SQL
 
@@ -13,7 +13,7 @@ class CourseController < ApplicationController
 	end
 
 	def like
-		@like = Like.find_or_create_by(user: current_user, course_id: params[:id])
+		@like = CourseLike.find_or_create_by(user: current_user, course_id: params[:id])
 		@like.amount += 1
 		@like.save!
 		render json: @like

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,3 @@
 class Comment < ApplicationRecord
+	belongs_to :parent, class_name: 'Comment', foreign_key: :parent_id
 end

--- a/app/models/comment_like.rb
+++ b/app/models/comment_like.rb
@@ -1,0 +1,4 @@
+class CommentLike < ApplicationRecord
+	belongs_to :comment
+	belongs_to :user
+end

--- a/app/models/course_like.rb
+++ b/app/models/course_like.rb
@@ -1,4 +1,4 @@
-class Like < ApplicationRecord
+class CourseLike < ApplicationRecord
 	belongs_to :course
 	belongs_to :user
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 	post 'user_token' => 'user_token#create'
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	post 'comment/:id/like', to: 'comment#like'
+	post 'comment/:id/reply', to: 'comment#reply'
 
 	get 'course/all', to: 'course#all'
 	get 'course/:id', to: 'course#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 	post 'user_token' => 'user_token#create'
 	# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+	post 'comment/:id/like', to: 'comment#like'
+
 	get 'course/all', to: 'course#all'
 	get 'course/:id', to: 'course#show'
 	post 'course/:id/like', to: 'course#like'

--- a/db/migrate/20171128203737_add_parent_column_to_comments.rb
+++ b/db/migrate/20171128203737_add_parent_column_to_comments.rb
@@ -1,0 +1,7 @@
+class AddParentColumnToComments < ActiveRecord::Migration[5.1]
+  def change
+  	change_table(:comments) do |t|
+  		t.references :parent, index: true, foreign_key: { to_table: :comments }
+  	end
+  end
+end

--- a/db/migrate/20171128211105_rename_likes_table_to_course_likes.rb
+++ b/db/migrate/20171128211105_rename_likes_table_to_course_likes.rb
@@ -1,0 +1,8 @@
+class RenameLikesTableToCourseLikes < ActiveRecord::Migration[5.1]
+  def up
+  	rename_table :likes, :course_likes
+  end
+  def down
+  	rename_table :course_likes, :likes
+  end
+end

--- a/db/migrate/20171128211752_create_comment_likes.rb
+++ b/db/migrate/20171128211752_create_comment_likes.rb
@@ -1,0 +1,13 @@
+class CreateCommentLikes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :comment_likes do |t|
+		t.integer :amount, default: 0, null: false
+
+		t.references :comment, foreign_key: true
+		t.references :user, foreign_key: true
+
+		t.index [:comment_id, :user_id], unique: true
+    	t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116044020) do
+ActiveRecord::Schema.define(version: 20171128203737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 20171116044020) do
     t.bigint "course_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "parent_id"
     t.index ["course_id"], name: "index_comments_on_course_id"
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
@@ -72,6 +74,7 @@ ActiveRecord::Schema.define(version: 20171116044020) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "comments", column: "parent_id"
   add_foreign_key "comments", "courses"
   add_foreign_key "comments", "users"
   add_foreign_key "courses", "instructors"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171128211105) do
+ActiveRecord::Schema.define(version: 20171128211752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comment_likes", force: :cascade do |t|
+    t.integer "amount", default: 0, null: false
+    t.bigint "comment_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id", "user_id"], name: "index_comment_likes_on_comment_id_and_user_id", unique: true
+    t.index ["comment_id"], name: "index_comment_likes_on_comment_id"
+    t.index ["user_id"], name: "index_comment_likes_on_user_id"
+  end
 
   create_table "comments", force: :cascade do |t|
     t.text "content", default: "", null: false
@@ -74,6 +85,8 @@ ActiveRecord::Schema.define(version: 20171128211105) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comment_likes", "comments"
+  add_foreign_key "comment_likes", "users"
   add_foreign_key "comments", "comments", column: "parent_id"
   add_foreign_key "comments", "courses"
   add_foreign_key "comments", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171128203737) do
+ActiveRecord::Schema.define(version: 20171128211105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20171128203737) do
     t.index ["course_id"], name: "index_comments_on_course_id"
     t.index ["parent_id"], name: "index_comments_on_parent_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "course_likes", force: :cascade do |t|
+    t.integer "amount", default: 0, null: false
+    t.bigint "course_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id", "user_id"], name: "index_course_likes_on_course_id_and_user_id", unique: true
+    t.index ["course_id"], name: "index_course_likes_on_course_id"
+    t.index ["user_id"], name: "index_course_likes_on_user_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -43,17 +54,6 @@ ActiveRecord::Schema.define(version: 20171128203737) do
 
   create_table "instructors", id: :string, force: :cascade do |t|
     t.string "rmp_url"
-  end
-
-  create_table "likes", force: :cascade do |t|
-    t.integer "amount", default: 0, null: false
-    t.bigint "course_id"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["course_id", "user_id"], name: "index_likes_on_course_id_and_user_id", unique: true
-    t.index ["course_id"], name: "index_likes_on_course_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "periods", id: false, force: :cascade do |t|
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20171128203737) do
   add_foreign_key "comments", "comments", column: "parent_id"
   add_foreign_key "comments", "courses"
   add_foreign_key "comments", "users"
+  add_foreign_key "course_likes", "courses"
+  add_foreign_key "course_likes", "users"
   add_foreign_key "courses", "instructors"
-  add_foreign_key "likes", "courses"
-  add_foreign_key "likes", "users"
 end

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comment_likes.yml
+++ b/test/fixtures/comment_likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_like_test.rb
+++ b/test/models/comment_like_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentLikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR adds the functionality to like and reply to a comment. All actions require authentication.

The likes table was separated out into two tables: comment_likes and course_likes.
The comments table has a new column called parent_id which references a comment parent or NULL.

A new comment controller is introduced with two actions:
reply: /comment/:id/reply
like: /comment/:id/like