### PR TITLE
[LOAD TEST FIRST] Create temp table creation background job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'pg'
 gem 'bcrypt'
 gem 'knock'
 gem 'faker'
+gem 'clockwork'
 
 gem 'email_validator'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
       xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    clockwork (2.0.2)
+      activesupport
+      tzinfo
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -217,6 +220,7 @@ DEPENDENCIES
   bcrypt
   byebug
   capybara (~> 2.13)
+  clockwork
   coffee-rails (~> 4.2)
   email_validator
   faker

--- a/app/controllers/course_controller.rb
+++ b/app/controllers/course_controller.rb
@@ -10,7 +10,7 @@ class CourseController < ApplicationController
 
 	def filter
 		filter_conditions = []
-		filter_conditions.push("courses.dept='#{params[:dept]}'") unless params[:dept].nil?
+		filter_conditions.push("dept='#{params[:dept]}'") unless params[:dept].nil?
 
 		filter_courses_sql = generate_filter_courses_sql(filter_conditions, params[:page])
 
@@ -50,11 +50,9 @@ class CourseController < ApplicationController
 		offset_sql = "OFFSET #{25 * params[:page].to_i}" unless page.nil?
 
 		<<-SQL
-			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
-			FROM courses
-			LEFT JOIN course_likes ON course_likes.course_id = courses.id
-			GROUP BY courses.id
-			ORDER BY likes
+			SELECT *
+			FROM course_likes_temp
+			ORDER BY likes DESC
 			LIMIT 25
 			#{offset_sql};
 		SQL
@@ -64,10 +62,10 @@ class CourseController < ApplicationController
 		offset_sql = "OFFSET #{25 * params[:page].to_i}" unless page.nil?
 
 		<<-SQL
-			SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
-			FROM courses LEFT JOIN course_likes ON course_likes.course_id = courses.id
+			SELECT *
+			FROM course_likes_temp
 			#{'WHERE ' + filter_conditions.join(' AND ') if filter_conditions.present?}
-			GROUP BY courses.id
+			ORDER BY likes DESC
 			LIMIT 25
 			#{offset_sql};
 		SQL

--- a/app/jobs/aggregate_courses_job.rb
+++ b/app/jobs/aggregate_courses_job.rb
@@ -3,18 +3,46 @@ class AggregateCoursesJob < ApplicationJob
 
 	def perform(*args)
 		temp_table_name = 'course_likes_temp'
-		create_temp_table_sql = generate_temp_table_sql(temp_table_name)
 
 		ActiveRecord::Base.transaction do
-			ActiveRecord::Base.connection.execute(create_temp_table_sql)
+			safe_replace_table(temp_table_name) do 
+				ActiveRecord::Base.connection.execute(generate_temp_table_sql(temp_table_name + '_new'))
+			end
 			ActiveRecord::Base.connection.execute(generate_index_sql(temp_table_name))
 		end
 	end
 
 private
+	def safe_replace_table(temp_table_name)
+		yield
+		ActiveRecord::Base.connection.execute(alter_table_if_exists(temp_table_name))
+		ActiveRecord::Base.connection.execute(rename_table(temp_table_name + '_new', temp_table_name))
+		ActiveRecord::Base.connection.execute(drop_table_if_exists(temp_table_name + '_old'))
+	end
+
+	def rename_table(old_table_name, new_table_name)
+		<<-SQL
+			ALTER TABLE "#{old_table_name}"
+			RENAME TO "#{new_table_name}"
+		SQL
+	end
+
+	def alter_table_if_exists(table_name)
+		<<-SQL
+			ALTER TABLE IF EXISTS "#{table_name}"
+			RENAME TO "#{table_name + '_old'}"
+		SQL
+	end
+
+	def drop_table_if_exists(table_name)
+		<<-SQL
+			DROP TABLE IF EXISTS "#{table_name}"
+		SQL
+	end
+
 	def generate_temp_table_sql(table_name)
 		<<-SQL
-			CREATE TEMP TABLE #{table_name}
+			CREATE TEMP TABLE "#{table_name}"
 			AS SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
 			FROM courses
 			LEFT JOIN course_likes ON course_likes.course_id = courses.id
@@ -33,20 +61,20 @@ private
 
 	def course_pkey(table_name)
 		<<-SQL
-			CREATE UNIQUE INDEX courses_pkey ON #{table_name} USING btree (id);
+			CREATE UNIQUE INDEX courses_pkey ON "#{table_name}" USING btree (id);
 		SQL
 	end
 
 	def instructor_dept_course_index(table_name)
 		<<-SQL
 			CREATE UNIQUE INDEX index_courses_on_instructor_id_and_dept_and_course_no
-	    	ON #{table_name} USING btree (instructor_id, dept, course_no);
+	    	ON "#{table_name}" USING btree (instructor_id, dept, course_no);
 		SQL
 	end
 
 	def instructor_index(table_name)
 		<<-SQL
-			CREATE INDEX index_courses_on_instructor_id ON #{table_name} USING btree (instructor_id);
+			CREATE INDEX index_courses_on_instructor_id ON "#{table_name}" USING btree (instructor_id);
 		SQL
 	end
 end

--- a/app/jobs/aggregate_courses_job.rb
+++ b/app/jobs/aggregate_courses_job.rb
@@ -1,0 +1,52 @@
+class AggregateCoursesJob < ApplicationJob
+	queue_as :default
+
+	def perform(*args)
+		temp_table_name = 'course_likes_temp'
+		create_temp_table_sql = generate_temp_table_sql(temp_table_name)
+
+		ActiveRecord::Base.transaction do
+			ActiveRecord::Base.connection.execute(create_temp_table_sql)
+			ActiveRecord::Base.connection.execute(generate_index_sql(temp_table_name))
+		end
+	end
+
+private
+	def generate_temp_table_sql(table_name)
+		<<-SQL
+			CREATE TEMP TABLE #{table_name}
+			AS SELECT courses.*, COALESCE(SUM(course_likes.amount), 0) as likes
+			FROM courses
+			LEFT JOIN course_likes ON course_likes.course_id = courses.id
+			GROUP BY courses.id
+			ORDER BY likes;
+		SQL
+	end
+
+	def generate_index_sql(table_name)
+		<<-SQL
+	    	#{course_pkey(table_name)}
+	    	#{instructor_dept_course_index(table_name)}
+	    	#{instructor_index(table_name)}
+	    SQL
+	end
+
+	def course_pkey(table_name)
+		<<-SQL
+			CREATE UNIQUE INDEX courses_pkey ON #{table_name} USING btree (id);
+		SQL
+	end
+
+	def instructor_dept_course_index(table_name)
+		<<-SQL
+			CREATE UNIQUE INDEX index_courses_on_instructor_id_and_dept_and_course_no
+	    	ON #{table_name} USING btree (instructor_id, dept, course_no);
+		SQL
+	end
+
+	def instructor_index(table_name)
+		<<-SQL
+			CREATE INDEX index_courses_on_instructor_id ON #{table_name} USING btree (instructor_id);
+		SQL
+	end
+end

--- a/app/jobs/aggregate_courses_job.rb
+++ b/app/jobs/aggregate_courses_job.rb
@@ -2,6 +2,7 @@ class AggregateCoursesJob < ApplicationJob
 	queue_as :default
 
 	def perform(*)
+		Rails.logger.info "aggregate courses job started"
 		temp_table_name = 'course_likes_temp'
 
 		ActiveRecord::Base.transaction do
@@ -10,6 +11,7 @@ class AggregateCoursesJob < ApplicationJob
 			end
 			ActiveRecord::Base.connection.execute(generate_index_sql(temp_table_name))
 		end
+		Rails.logger.info "aggregate courses job started"
 	end
 
 		private

--- a/app/jobs/aggregate_courses_job.rb
+++ b/app/jobs/aggregate_courses_job.rb
@@ -58,6 +58,7 @@ class AggregateCoursesJob < ApplicationJob
 	    	#{course_pkey(*args)}
 	    	#{instructor_dept_course_index(*args)}
 	    	#{instructor_index(*args)}
+	    	#{likes_index(*args)}
 	    SQL
 	end
 
@@ -77,6 +78,12 @@ class AggregateCoursesJob < ApplicationJob
 	def instructor_index(table_name, timestamp)
 		<<-SQL
 			CREATE INDEX index_courses_on_instructor_id_#{timestamp} ON "#{table_name}" USING btree (instructor_id);
+		SQL
+	end
+
+	def likes_index(table_name, timestamp)
+		<<-SQL
+			CREATE INDEX index_courses_on_likes_#{timestamp} ON "#{table_name}" USING btree (likes);
 		SQL
 	end
 end

--- a/app/jobs/aggregate_courses_job.rb
+++ b/app/jobs/aggregate_courses_job.rb
@@ -1,18 +1,19 @@
 class AggregateCoursesJob < ApplicationJob
 	queue_as :default
 
-	def perform(*args)
+	def perform(*)
 		temp_table_name = 'course_likes_temp'
 
 		ActiveRecord::Base.transaction do
-			safe_replace_table(temp_table_name) do 
+			safe_replace_table(temp_table_name) do
 				ActiveRecord::Base.connection.execute(generate_temp_table_sql(temp_table_name + '_new'))
 			end
 			ActiveRecord::Base.connection.execute(generate_index_sql(temp_table_name))
 		end
 	end
 
-private
+		private
+
 	def safe_replace_table(temp_table_name)
 		yield
 		ActiveRecord::Base.connection.execute(alter_table_if_exists(temp_table_name))

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,17 +7,20 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module UcsbClassScheduler
-  class Application < Rails::Application
-    config.api_only = true
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+	class Application < Rails::Application
+		config.api_only = true
+		# Initialize configuration defaults for originally generated Rails version.
+		config.load_defaults 5.1
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+		# Settings in config/environments/* take precedence over those specified here.
+		# Application configuration should go into files in config/initializers
+		# -- all .rb files in that directory are automatically loaded.
 
-    config.after_initialize do
-		AggregateCoursesJob.perform_now
-    end
-  end
+		config.after_initialize do
+			if ENV["MASTER_PROC"] == "true"
+				AggregateCoursesJob.perform_now
+				exec("MASTER_PROC=false bundle exec clockwork lib/clock.rb") if fork.nil?
+			end
+		end
+	end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,9 @@ module UcsbClassScheduler
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.after_initialize do
+		AggregateCoursesJob.perform_now
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.logger = Logger.new(STDOUT)
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../../config/boot', __FILE__)
+
+require File.expand_path('../../config/environment', __FILE__)
+
+require 'clockwork'
+include Clockwork
+
+handler { |job| p job }
+every(1.minute, 'AggregateCourses.job') { AggregateCoursesJob.perform_later }

--- a/test/jobs/aggregate_courses_job_test.rb
+++ b/test/jobs/aggregate_courses_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AggregateCoursesJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Creating temp tables for performance increase.

Job Time for 1 million records: 8 - 15 s
Result: 100x - 900x increase in fetch time for subsequent queries related to the temp table

Look into adding a scheduling/task based service

Using => https://github.com/adamwiggins/clockwork